### PR TITLE
geom_alt props

### DIFF
--- a/data/421/182/367/421182367.geojson
+++ b/data/421/182/367/421182367.geojson
@@ -689,6 +689,10 @@
     },
     "wof:country":"AM",
     "wof:created":1459009327,
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ebde5e604774ebe72a942980b9802dfa",
     "wof:hierarchy":[
         {
@@ -699,7 +703,7 @@
         }
     ],
     "wof:id":421182367,
-    "wof:lastmodified":1566585519,
+    "wof:lastmodified":1582318253,
     "wof:name":"Yerevan",
     "wof:parent_id":85668115,
     "wof:placetype":"locality",

--- a/data/856/327/73/85632773.geojson
+++ b/data/856/327/73/85632773.geojson
@@ -1040,6 +1040,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1094,6 +1095,10 @@
     },
     "wof:country":"AM",
     "wof:country_alpha3":"ARM",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"41bcce129722b6c9b76440b6c1e3ff2e",
     "wof:hierarchy":[
         {
@@ -1108,7 +1113,7 @@
     "wof:lang_x_spoken":[
         "hye"
     ],
-    "wof:lastmodified":1566585172,
+    "wof:lastmodified":1582318247,
     "wof:name":"Armenia",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/327/73/85632773.geojson
+++ b/data/856/327/73/85632773.geojson
@@ -1040,7 +1040,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1113,7 +1112,7 @@
     "wof:lang_x_spoken":[
         "hye"
     ],
-    "wof:lastmodified":1582318247,
+    "wof:lastmodified":1583204874,
     "wof:name":"Armenia",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/859/037/25/85903725.geojson
+++ b/data/859/037/25/85903725.geojson
@@ -67,6 +67,9 @@
         "qs_pg:id":1130257
     },
     "wof:country":"AM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f7182e57be3c9b53e3f849eb70d054ae",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585169,
+    "wof:lastmodified":1582318247,
     "wof:name":"Charbakh",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/27/85903727.geojson
+++ b/data/859/037/27/85903727.geojson
@@ -86,6 +86,10 @@
         "wk:page":"Imeni Tairova"
     },
     "wof:country":"AM",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e60102b6284ad69ecc3f5b1d4e03a14d",
     "wof:hierarchy":[
         {
@@ -100,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585169,
+    "wof:lastmodified":1582318246,
     "wof:name":"Imeni Tairova",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/29/85903729.geojson
+++ b/data/859/037/29/85903729.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":1083723
     },
     "wof:country":"AM",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"99c3570341f30fb3f7c2d39e4e2a99c1",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585169,
+    "wof:lastmodified":1582318246,
     "wof:name":"Nork",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/33/85903733.geojson
+++ b/data/859/037/33/85903733.geojson
@@ -67,6 +67,10 @@
         "qs_pg:id":1130268
     },
     "wof:country":"AM",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a7b30f888723784503baedad62ec8659",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585169,
+    "wof:lastmodified":1582318246,
     "wof:name":"Sari T'ag",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/35/85903735.geojson
+++ b/data/859/037/35/85903735.geojson
@@ -72,6 +72,9 @@
         "gp:id":2214371
     },
     "wof:country":"AM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3ac5fb3585819cb05a6322d2ea0123da",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566585169,
+    "wof:lastmodified":1582318246,
     "wof:name":"Spandaryan",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/433/451/890433451.geojson
+++ b/data/890/433/451/890433451.geojson
@@ -361,6 +361,9 @@
     },
     "wof:country":"AM",
     "wof:created":1469051981,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b0976eb6ffb8ba69dcea84a2d52e6927",
     "wof:hierarchy":[
         {
@@ -372,7 +375,7 @@
         }
     ],
     "wof:id":890433451,
-    "wof:lastmodified":1566585531,
+    "wof:lastmodified":1582318253,
     "wof:name":"Vanadzor",
     "wof:parent_id":1108783523,
     "wof:placetype":"locality",

--- a/data/890/449/917/890449917.geojson
+++ b/data/890/449/917/890449917.geojson
@@ -451,6 +451,9 @@
     },
     "wof:country":"AM",
     "wof:created":1469052716,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"13bd6b81e79dc39042d78fb46dde51b3",
     "wof:hierarchy":[
         {
@@ -462,7 +465,7 @@
         }
     ],
     "wof:id":890449917,
-    "wof:lastmodified":1566585523,
+    "wof:lastmodified":1582318253,
     "wof:name":"Artashat",
     "wof:parent_id":1108784229,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.