### PR TITLE
Update properties of megacities

### DIFF
--- a/data/421/182/367/421182367.geojson
+++ b/data/421/182/367/421182367.geojson
@@ -683,6 +683,7 @@
     "wof:concordances":{
         "gn:id":616052,
         "gp:id":2214662,
+        "ne:id":1159151119,
         "qs_pg:id":126142,
         "wd:id":"Q1953"
     },
@@ -705,7 +706,8 @@
         }
     ],
     "wof:id":421182367,
-    "wof:lastmodified":1607390900,
+    "wof:lastmodified":1608688179,
+    "wof:megacity":1,
     "wof:name":"Yerevan",
     "wof:parent_id":85668115,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary