### PR TITLE
am concordances, placetype local, and more

### DIFF
--- a/data/421/166/665/421166665.geojson
+++ b/data/421/166/665/421166665.geojson
@@ -62,7 +62,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459008698,
-    "wof:geomhash":"78b4afb971043fa312bd08445c490648",
+    "wof:geomhash":"6f2fa5a7a6c4e2fb49c2ef54a45adc01",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":421166665,
-    "wof:lastmodified":1627521474,
+    "wof:lastmodified":1695887498,
     "wof:name":"Oktemberyan",
     "wof:parent_id":85668085,
     "wof:placetype":"county",

--- a/data/421/169/937/421169937.geojson
+++ b/data/421/169/937/421169937.geojson
@@ -143,7 +143,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459008830,
-    "wof:geomhash":"074161c4e3eca632db5a6ceccd2a75be",
+    "wof:geomhash":"14bbbce788851eb4336373993d244301",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -153,7 +153,7 @@
         }
     ],
     "wof:id":421169937,
-    "wof:lastmodified":1566585492,
+    "wof:lastmodified":1695886950,
     "wof:name":"Berd",
     "wof:parent_id":85668095,
     "wof:placetype":"county",

--- a/data/421/171/429/421171429.geojson
+++ b/data/421/171/429/421171429.geojson
@@ -92,7 +92,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459008893,
-    "wof:geomhash":"57238b4247b1ea2b8ad901e6ef5fdb33",
+    "wof:geomhash":"8850996df2006f183efe62f8863c977f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -102,7 +102,7 @@
         }
     ],
     "wof:id":421171429,
-    "wof:lastmodified":1566585520,
+    "wof:lastmodified":1695886951,
     "wof:name":"Gugark",
     "wof:parent_id":85668105,
     "wof:placetype":"county",

--- a/data/421/172/441/421172441.geojson
+++ b/data/421/172/441/421172441.geojson
@@ -62,7 +62,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459008942,
-    "wof:geomhash":"ae7aa2f6ab4ca7d036247b5ad3ec5ae8",
+    "wof:geomhash":"0ae0e91e195a6fb21e92b7cd96972e35",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":421172441,
-    "wof:lastmodified":1627521475,
+    "wof:lastmodified":1695887498,
     "wof:name":"Yegvard",
     "wof:parent_id":85668105,
     "wof:placetype":"county",

--- a/data/421/173/949/421173949.geojson
+++ b/data/421/173/949/421173949.geojson
@@ -65,7 +65,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009012,
-    "wof:geomhash":"e33962b33e2be93a7294c70ae881bfac",
+    "wof:geomhash":"33a8593669d10ac8357d00fb2ce601ed",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +75,7 @@
         }
     ],
     "wof:id":421173949,
-    "wof:lastmodified":1627521475,
+    "wof:lastmodified":1695887498,
     "wof:name":"Razdan",
     "wof:parent_id":85668105,
     "wof:placetype":"county",

--- a/data/421/175/281/421175281.geojson
+++ b/data/421/175/281/421175281.geojson
@@ -62,7 +62,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009061,
-    "wof:geomhash":"6c385f49a1447ac6a851434df3f143f2",
+    "wof:geomhash":"22877b38026b86a45affab9ce5ccd517",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":421175281,
-    "wof:lastmodified":1627521475,
+    "wof:lastmodified":1695887498,
     "wof:name":"Kafan",
     "wof:parent_id":85668119,
     "wof:placetype":"county",

--- a/data/421/182/247/421182247.geojson
+++ b/data/421/182/247/421182247.geojson
@@ -107,7 +107,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009323,
-    "wof:geomhash":"8333c6eede784010accf6c19ab7c29f1",
+    "wof:geomhash":"04ca35fd4ceac95b93a8c0f75e083665",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -117,7 +117,7 @@
         }
     ],
     "wof:id":421182247,
-    "wof:lastmodified":1566585519,
+    "wof:lastmodified":1695886951,
     "wof:name":"Kamo",
     "wof:parent_id":85668103,
     "wof:placetype":"county",

--- a/data/421/183/897/421183897.geojson
+++ b/data/421/183/897/421183897.geojson
@@ -155,7 +155,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009391,
-    "wof:geomhash":"7cbc1a371f95d6786e7a4e2f8c0e75b0",
+    "wof:geomhash":"f4cedb83eaaef9c5c7bbbbd4ef83a1ad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -165,7 +165,7 @@
         }
     ],
     "wof:id":421183897,
-    "wof:lastmodified":1566585515,
+    "wof:lastmodified":1695886951,
     "wof:name":"Stepanavan",
     "wof:parent_id":85668109,
     "wof:placetype":"county",

--- a/data/421/184/071/421184071.geojson
+++ b/data/421/184/071/421184071.geojson
@@ -68,7 +68,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009399,
-    "wof:geomhash":"ffb6cc245f2555a7cf1c8ea60d6c589b",
+    "wof:geomhash":"7847bd60ebcbc790128caa0ecc58e00f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":421184071,
-    "wof:lastmodified":1627521475,
+    "wof:lastmodified":1695887498,
     "wof:name":"Krasnoselsk",
     "wof:parent_id":85668103,
     "wof:placetype":"county",

--- a/data/421/186/199/421186199.geojson
+++ b/data/421/186/199/421186199.geojson
@@ -101,7 +101,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009473,
-    "wof:geomhash":"1063aab4f2054a00060f932dd1efe9e0",
+    "wof:geomhash":"818e87b9e7566bcfc935190eb0aa284f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -111,7 +111,7 @@
         }
     ],
     "wof:id":421186199,
-    "wof:lastmodified":1566585500,
+    "wof:lastmodified":1695886951,
     "wof:name":"Sevan",
     "wof:parent_id":85668103,
     "wof:placetype":"county",

--- a/data/421/186/201/421186201.geojson
+++ b/data/421/186/201/421186201.geojson
@@ -191,7 +191,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009473,
-    "wof:geomhash":"7e9981043e2b8e6773d57edc1f7bf6cf",
+    "wof:geomhash":"6d5309da610b3260b2d5cc41cf509e99",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -201,7 +201,7 @@
         }
     ],
     "wof:id":421186201,
-    "wof:lastmodified":1636495573,
+    "wof:lastmodified":1695887131,
     "wof:name":"Yeghegnadzor",
     "wof:parent_id":85668123,
     "wof:placetype":"county",

--- a/data/421/186/283/421186283.geojson
+++ b/data/421/186/283/421186283.geojson
@@ -80,7 +80,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009476,
-    "wof:geomhash":"06bc9844812bfbdf4de192fdb1ea3155",
+    "wof:geomhash":"d5acbc587411b20659a6047ad0eb2657",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -90,7 +90,7 @@
         }
     ],
     "wof:id":421186283,
-    "wof:lastmodified":1566585500,
+    "wof:lastmodified":1695886951,
     "wof:name":"Masis",
     "wof:parent_id":85668105,
     "wof:placetype":"county",

--- a/data/421/186/285/421186285.geojson
+++ b/data/421/186/285/421186285.geojson
@@ -167,7 +167,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009476,
-    "wof:geomhash":"66e40687ea4950749fa75e936d075ff0",
+    "wof:geomhash":"f8caae24796b280795d6386fa6b5614e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -177,7 +177,7 @@
         }
     ],
     "wof:id":421186285,
-    "wof:lastmodified":1566585500,
+    "wof:lastmodified":1695886951,
     "wof:name":"Sisian",
     "wof:parent_id":85668119,
     "wof:placetype":"county",

--- a/data/421/186/287/421186287.geojson
+++ b/data/421/186/287/421186287.geojson
@@ -95,7 +95,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009476,
-    "wof:geomhash":"88658f83295cc3f91e828e37366625a1",
+    "wof:geomhash":"89a6fa5d8717b9adf436d7fa9d8c2bee",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -105,7 +105,7 @@
         }
     ],
     "wof:id":421186287,
-    "wof:lastmodified":1566585500,
+    "wof:lastmodified":1695886951,
     "wof:name":"Martuni",
     "wof:parent_id":85668103,
     "wof:placetype":"county",

--- a/data/421/187/993/421187993.geojson
+++ b/data/421/187/993/421187993.geojson
@@ -62,7 +62,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009530,
-    "wof:geomhash":"2f8c0076731c2935d90a99aa1dbf168a",
+    "wof:geomhash":"c07e2d028abc004ec76185f8130756a5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":421187993,
-    "wof:lastmodified":1627521475,
+    "wof:lastmodified":1695887498,
     "wof:name":"Idzhevan",
     "wof:parent_id":85668095,
     "wof:placetype":"county",

--- a/data/421/190/417/421190417.geojson
+++ b/data/421/190/417/421190417.geojson
@@ -77,7 +77,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009657,
-    "wof:geomhash":"7b32d9b2dc37b26a1c5f0ed67cc8d9fb",
+    "wof:geomhash":"3293e57290d8c5512a5aacae59afadc0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -87,7 +87,7 @@
         }
     ],
     "wof:id":421190417,
-    "wof:lastmodified":1627521475,
+    "wof:lastmodified":1695887498,
     "wof:name":"Megri",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/421/190/999/421190999.geojson
+++ b/data/421/190/999/421190999.geojson
@@ -158,7 +158,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009676,
-    "wof:geomhash":"94fa352f77e002cd3813ac078f179473",
+    "wof:geomhash":"7a5cfe4becd6ef13f809627d0b3e61f1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -168,7 +168,7 @@
         }
     ],
     "wof:id":421190999,
-    "wof:lastmodified":1566585504,
+    "wof:lastmodified":1695886951,
     "wof:name":"Artik",
     "wof:parent_id":85668083,
     "wof:placetype":"county",

--- a/data/421/191/001/421191001.geojson
+++ b/data/421/191/001/421191001.geojson
@@ -173,7 +173,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009676,
-    "wof:geomhash":"500567ea4d57c34cbdb2a8247ed61cf6",
+    "wof:geomhash":"701adef5ae5bd40a6bab72982fd7fc5e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -183,7 +183,7 @@
         }
     ],
     "wof:id":421191001,
-    "wof:lastmodified":1566585504,
+    "wof:lastmodified":1695886951,
     "wof:name":"Vardenis",
     "wof:parent_id":85668103,
     "wof:placetype":"county",

--- a/data/421/191/733/421191733.geojson
+++ b/data/421/191/733/421191733.geojson
@@ -161,7 +161,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009703,
-    "wof:geomhash":"74972c092a252c061d0575d8dfce48d4",
+    "wof:geomhash":"38488fd7da049f1d3a17bcdddb6a1d48",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -171,7 +171,7 @@
         }
     ],
     "wof:id":421191733,
-    "wof:lastmodified":1566585504,
+    "wof:lastmodified":1695886951,
     "wof:name":"Vedi",
     "wof:parent_id":85668099,
     "wof:placetype":"county",

--- a/data/421/192/835/421192835.geojson
+++ b/data/421/192/835/421192835.geojson
@@ -62,7 +62,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009750,
-    "wof:geomhash":"fde045a5f7b01a4457b6f8aa87980cb3",
+    "wof:geomhash":"6e7213e5064678e11d495973e5fad5be",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":421192835,
-    "wof:lastmodified":1627521475,
+    "wof:lastmodified":1695887498,
     "wof:name":"Tsakhkaovit",
     "wof:parent_id":85668089,
     "wof:placetype":"county",

--- a/data/421/194/653/421194653.geojson
+++ b/data/421/194/653/421194653.geojson
@@ -188,7 +188,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009815,
-    "wof:geomhash":"a662f15136af92781735c651fb2ef68d",
+    "wof:geomhash":"7c6bbfcc73284d6c897fc8496d5fed47",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -198,7 +198,7 @@
         }
     ],
     "wof:id":421194653,
-    "wof:lastmodified":1566585490,
+    "wof:lastmodified":1695886950,
     "wof:name":"Abovyan",
     "wof:parent_id":85668099,
     "wof:placetype":"county",

--- a/data/421/194/655/421194655.geojson
+++ b/data/421/194/655/421194655.geojson
@@ -80,7 +80,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009815,
-    "wof:geomhash":"1614480fa25dc6ccfc7ea5abb21821db",
+    "wof:geomhash":"9db16b51b4bfdf706ebdb660175a91ce",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -90,7 +90,7 @@
         }
     ],
     "wof:id":421194655,
-    "wof:lastmodified":1566585489,
+    "wof:lastmodified":1695886950,
     "wof:name":"Alaverdi",
     "wof:parent_id":85668109,
     "wof:placetype":"county",

--- a/data/421/194/657/421194657.geojson
+++ b/data/421/194/657/421194657.geojson
@@ -62,7 +62,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009815,
-    "wof:geomhash":"81bd34a673bcfa363952bce61ef810a5",
+    "wof:geomhash":"cd6837b1dd0333d7656d20c55d15c3c6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":421194657,
-    "wof:lastmodified":1627521475,
+    "wof:lastmodified":1695887498,
     "wof:name":"Echmiadzin",
     "wof:parent_id":85668085,
     "wof:placetype":"county",

--- a/data/421/194/659/421194659.geojson
+++ b/data/421/194/659/421194659.geojson
@@ -182,7 +182,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009815,
-    "wof:geomhash":"96531f5a0186ab96c487343d01b78637",
+    "wof:geomhash":"5a4af340a917d2a1b3061e4efa03342e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -192,7 +192,7 @@
         }
     ],
     "wof:id":421194659,
-    "wof:lastmodified":1566585488,
+    "wof:lastmodified":1695886950,
     "wof:name":"Goris",
     "wof:parent_id":85668119,
     "wof:placetype":"county",

--- a/data/421/194/661/421194661.geojson
+++ b/data/421/194/661/421194661.geojson
@@ -71,7 +71,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009815,
-    "wof:geomhash":"d1d84f290dd06439be2953354f54df46",
+    "wof:geomhash":"115919a64ba8728b079861e5340ea1a9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +81,7 @@
         }
     ],
     "wof:id":421194661,
-    "wof:lastmodified":1636495572,
+    "wof:lastmodified":1695887131,
     "wof:name":"Artashat",
     "wof:parent_id":85668105,
     "wof:placetype":"county",

--- a/data/421/194/665/421194665.geojson
+++ b/data/421/194/665/421194665.geojson
@@ -188,7 +188,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009815,
-    "wof:geomhash":"964ac607d023fc0c853b64e0387b6ae9",
+    "wof:geomhash":"06237d189989a4c6cadd033700c418b3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -198,7 +198,7 @@
         }
     ],
     "wof:id":421194665,
-    "wof:lastmodified":1636495572,
+    "wof:lastmodified":1695887131,
     "wof:name":"Ashtarak",
     "wof:parent_id":85668083,
     "wof:placetype":"county",

--- a/data/421/194/769/421194769.geojson
+++ b/data/421/194/769/421194769.geojson
@@ -164,7 +164,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009819,
-    "wof:geomhash":"4cd1444f6a6770cedfd92930820d3d83",
+    "wof:geomhash":"eb595a2c3ae5297cb989360b00178aed",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -174,7 +174,7 @@
         }
     ],
     "wof:id":421194769,
-    "wof:lastmodified":1566585489,
+    "wof:lastmodified":1695886950,
     "wof:name":"Aparan",
     "wof:parent_id":85668083,
     "wof:placetype":"county",

--- a/data/421/194/773/421194773.geojson
+++ b/data/421/194/773/421194773.geojson
@@ -62,7 +62,7 @@
     },
     "wof:country":"AM",
     "wof:created":1459009819,
-    "wof:geomhash":"036a9d114cfeebffff67431b3c1cea7a",
+    "wof:geomhash":"d8bb24fa424a7743611b194e8963a3fa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":421194773,
-    "wof:lastmodified":1627521475,
+    "wof:lastmodified":1695887498,
     "wof:name":"Azizbekov",
     "wof:parent_id":85668123,
     "wof:placetype":"county",

--- a/data/856/327/73/85632773.geojson
+++ b/data/856/327/73/85632773.geojson
@@ -1244,6 +1244,7 @@
         "hasc:id":"AM",
         "icao:code":"EK",
         "ioc:id":"ARM",
+        "iso:code":"AM",
         "itu:id":"ARM",
         "m49:code":"051",
         "marc:id":"ai",
@@ -1257,6 +1258,7 @@
         "wk:page":"Armenia",
         "wmo:id":"AY"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AM",
     "wof:country_alpha3":"ARM",
     "wof:geom_alt":[
@@ -1279,7 +1281,7 @@
     "wof:lang_x_spoken":[
         "hye"
     ],
-    "wof:lastmodified":1694639595,
+    "wof:lastmodified":1695881255,
     "wof:name":"Armenia",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/680/83/85668083.geojson
+++ b/data/856/680/83/85668083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.288693,
-    "geom:area_square_m":2717591384.884384,
+    "geom:area_square_m":2717592457.957134,
     "geom:bbox":"43.594217,40.18517,44.553281,40.742888",
     "geom:latitude":40.422306,
     "geom:longitude":44.139195,
@@ -377,13 +377,15 @@
         "gn:id":828259,
         "gp:id":20070209,
         "hasc:id":"AM.AG",
+        "iso:code":"AM-AG",
         "iso:id":"AM-AG",
         "qs_pg:id":219913,
         "wd:id":"Q17915",
         "wk:page":"Aragatsotn Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AM",
-    "wof:geomhash":"33f1149cb362fa7432aea5a37a7af748",
+    "wof:geomhash":"57866c06a114fa41c6971ede4e0ab284",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -398,7 +400,7 @@
     "wof:lang_x_spoken":[
         "hye"
     ],
-    "wof:lastmodified":1690849805,
+    "wof:lastmodified":1695884798,
     "wof:name":"Aragatsotn",
     "wof:parent_id":85632773,
     "wof:placetype":"region",

--- a/data/856/680/85/85668085.geojson
+++ b/data/856/680/85/85668085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.131778,
-    "geom:area_square_m":1245779755.959867,
+    "geom:area_square_m":1245779062.372537,
     "geom:bbox":"43.652508,40.008618,44.440471,40.284932",
     "geom:latitude":40.134845,
     "geom:longitude":44.035734,
@@ -367,14 +367,16 @@
         "gn:id":828260,
         "gp:id":20070210,
         "hasc:id":"AM.AV",
+        "iso:code":"AM-AV",
         "iso:id":"AM-AV",
         "qs_pg:id":1102976,
         "unlc:id":"AM-AV",
         "wd:id":"Q201147",
         "wk:page":"Armavir Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AM",
-    "wof:geomhash":"102573e24cc6223ebb773f3acf17b093",
+    "wof:geomhash":"775b376fa5dceaf530364c1caf2e486e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -389,7 +391,7 @@
     "wof:lang_x_spoken":[
         "hye"
     ],
-    "wof:lastmodified":1690849805,
+    "wof:lastmodified":1695884798,
     "wof:name":"Armavir",
     "wof:parent_id":85632773,
     "wof:placetype":"region",

--- a/data/856/680/89/85668089.geojson
+++ b/data/856/680/89/85668089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.308063,
-    "geom:area_square_m":2883509817.737524,
+    "geom:area_square_m":2883509649.899809,
     "geom:bbox":"43.436294,40.409317,44.199607,41.164537",
     "geom:latitude":40.80142,
     "geom:longitude":43.851535,
@@ -367,13 +367,15 @@
         "gn:id":828264,
         "gp:id":20070203,
         "hasc:id":"AM.SH",
+        "iso:code":"AM-SH",
         "iso:id":"AM-SH",
         "qs_pg:id":1102965,
         "wd:id":"Q201063",
         "wk:page":"Shirak Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AM",
-    "wof:geomhash":"f6283657bf8fe87b58a2666e155c4a46",
+    "wof:geomhash":"0bf0fa008e8bdb03ea6b97619987fcf5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -388,7 +390,7 @@
     "wof:lang_x_spoken":[
         "hye"
     ],
-    "wof:lastmodified":1690849804,
+    "wof:lastmodified":1695884797,
     "wof:name":"Shirak",
     "wof:parent_id":85632773,
     "wof:placetype":"region",

--- a/data/856/680/95/85668095.geojson
+++ b/data/856/680/95/85668095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.280658,
-    "geom:area_square_m":2623130354.340147,
+    "geom:area_square_m":2623131704.768621,
     "geom:bbox":"44.751873,40.637649,45.600968,41.290452",
     "geom:latitude":40.899125,
     "geom:longitude":45.119388,
@@ -376,13 +376,15 @@
         "gn:id":828265,
         "gp:id":20070202,
         "hasc:id":"AM.TV",
+        "iso:code":"AM-TV",
         "iso:id":"AM-TV",
         "qs_pg:id":523994,
         "wd:id":"Q201140",
         "wk:page":"Tavush Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AM",
-    "wof:geomhash":"0d799e2ab5fd366fc4c9e2a3c340ff52",
+    "wof:geomhash":"a583aec1d7e684cd00f4dae9c560e6ac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -397,7 +399,7 @@
     "wof:lang_x_spoken":[
         "hye"
     ],
-    "wof:lastmodified":1690849804,
+    "wof:lastmodified":1695884797,
     "wof:name":"Tavush",
     "wof:parent_id":85632773,
     "wof:placetype":"region",

--- a/data/856/680/99/85668099.geojson
+++ b/data/856/680/99/85668099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.208044,
-    "geom:area_square_m":1972219496.613733,
+    "geom:area_square_m":1972220378.036425,
     "geom:bbox":"44.351226,39.702797,45.109526,40.164991",
     "geom:latitude":39.94572,
     "geom:longitude":44.788504,
@@ -360,14 +360,16 @@
         "gn:id":409313,
         "gp:id":20070211,
         "hasc:id":"AM.AR",
+        "iso:code":"AM-AR",
         "iso:id":"AM-AR",
         "qs_pg:id":1118847,
         "unlc:id":"AM-AR",
         "wd:id":"Q199880",
         "wk:page":"Ararat Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AM",
-    "wof:geomhash":"61082f0eb602468bfdd1ce1e9ae6c97c",
+    "wof:geomhash":"ef30d6a876e2e41a8bfceed109d082da",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -382,7 +384,7 @@
     "wof:lang_x_spoken":[
         "hye"
     ],
-    "wof:lastmodified":1690849805,
+    "wof:lastmodified":1695884798,
     "wof:name":"Ararat",
     "wof:parent_id":85632773,
     "wof:placetype":"region",

--- a/data/856/681/03/85668103.geojson
+++ b/data/856/681/03/85668103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.558372,
-    "geom:area_square_m":5266267502.938733,
+    "geom:area_square_m":5266268517.226079,
     "geom:bbox":"44.788047,39.865784,45.981772,40.733793",
     "geom:latitude":40.292772,
     "geom:longitude":45.337342,
@@ -375,13 +375,15 @@
         "gn:id":828261,
         "gp:id":20070204,
         "hasc:id":"AM.GR",
+        "iso:code":"AM-GR",
         "iso:id":"AM-GR",
         "qs_pg:id":1030251,
         "wd:id":"Q199905",
         "wk:page":"Gegharkunik Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AM",
-    "wof:geomhash":"dfe1a957f24612a132ac86f132d916a4",
+    "wof:geomhash":"8191eab8a85a374d24bc03936aba4fb9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -396,7 +398,7 @@
     "wof:lang_x_spoken":[
         "hye"
     ],
-    "wof:lastmodified":1690849802,
+    "wof:lastmodified":1695884797,
     "wof:name":"Gegharkunik",
     "wof:parent_id":85632773,
     "wof:placetype":"region",

--- a/data/856/681/05/85668105.geojson
+++ b/data/856/681/05/85668105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.225174,
-    "geom:area_square_m":2120964175.075218,
+    "geom:area_square_m":2120962778.122659,
     "geom:bbox":"44.408328,40.08329,45.029789,40.699687",
     "geom:latitude":40.380148,
     "geom:longitude":44.692995,
@@ -375,13 +375,15 @@
         "gn:id":828262,
         "gp:id":20070208,
         "hasc:id":"AM.KT",
+        "iso:code":"AM-KT",
         "iso:id":"AM-KT",
         "qs_pg:id":219650,
         "unlc:id":"AM-KT",
         "wd:id":"Q4511"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AM",
-    "wof:geomhash":"05b1f116cbef36b2471d44d73a3f3a8c",
+    "wof:geomhash":"ae89c86347d02c6895fc2df4aa2cc1ec",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -396,7 +398,7 @@
     "wof:lang_x_spoken":[
         "hye"
     ],
-    "wof:lastmodified":1690849802,
+    "wof:lastmodified":1695884324,
     "wof:name":"Kotayk",
     "wof:parent_id":85632773,
     "wof:placetype":"region",

--- a/data/856/681/09/85668109.geojson
+++ b/data/856/681/09/85668109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.399686,
-    "geom:area_square_m":3731873761.817788,
+    "geom:area_square_m":3731874791.328012,
     "geom:bbox":"43.966082,40.661498,44.938684,41.230043",
     "geom:latitude":40.965215,
     "geom:longitude":44.459755,
@@ -370,13 +370,15 @@
         "gn:id":828263,
         "gp:id":20070207,
         "hasc:id":"AM.LO",
+        "iso:code":"AM-LO",
         "iso:id":"AM-LO",
         "qs_pg:id":896391,
         "wd:id":"Q200350",
         "wk:page":"Lori Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AM",
-    "wof:geomhash":"be324895f1d836683aec85e99a601bd0",
+    "wof:geomhash":"02c46f3b17ee90a9ceb9bc1f2ff6fdaa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -391,7 +393,7 @@
     "wof:lang_x_spoken":[
         "hye"
     ],
-    "wof:lastmodified":1690849803,
+    "wof:lastmodified":1695884797,
     "wof:name":"Lori",
     "wof:parent_id":85632773,
     "wof:placetype":"region",

--- a/data/856/681/15/85668115.geojson
+++ b/data/856/681/15/85668115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022924,
-    "geom:area_square_m":216676642.070711,
+    "geom:area_square_m":216676382.816114,
     "geom:bbox":"44.418405,40.054093,44.64759,40.229173",
     "geom:latitude":40.147433,
     "geom:longitude":44.536223,
@@ -727,14 +727,16 @@
         "gn:id":616051,
         "gp:id":20070212,
         "hasc:id":"AM.ER",
+        "iso:code":"AM-ER",
         "iso:id":"AM-ER",
         "qs_pg:id":892919,
         "unlc:id":"AM-ER",
         "wd:id":"Q1953",
         "wk:page":"Yerevan"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AM",
-    "wof:geomhash":"9e2e783876283f51b3b0c4ba64ca5228",
+    "wof:geomhash":"59874d8fb625c46257c57cc852347177",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -749,7 +751,7 @@
     "wof:lang_x_spoken":[
         "hye"
     ],
-    "wof:lastmodified":1690849804,
+    "wof:lastmodified":1695884324,
     "wof:name":"Yerevan",
     "wof:parent_id":85632773,
     "wof:placetype":"region",

--- a/data/856/681/19/85668119.geojson
+++ b/data/856/681/19/85668119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.460184,
-    "geom:area_square_m":4400389718.080212,
+    "geom:area_square_m":4400387798.690931,
     "geom:bbox":"45.701221,38.863701,46.602612,39.851262",
     "geom:latitude":39.346663,
     "geom:longitude":46.139942,
@@ -374,13 +374,15 @@
         "gn:id":409314,
         "gp:id":20070206,
         "hasc:id":"AM.SU",
+        "iso:code":"AM-SU",
         "iso:id":"AM-SU",
         "qs_pg:id":1098498,
         "unlc:id":"AM-SU",
         "wd:id":"Q2523428"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AM",
-    "wof:geomhash":"27d34c3f57ed1484d07f824657e47ac7",
+    "wof:geomhash":"9891453fb9f7a78789cf744d71f35e71",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -395,7 +397,7 @@
     "wof:lang_x_spoken":[
         "hye"
     ],
-    "wof:lastmodified":1690849803,
+    "wof:lastmodified":1695884798,
     "wof:name":"Syunik",
     "wof:parent_id":85632773,
     "wof:placetype":"region",

--- a/data/856/681/23/85668123.geojson
+++ b/data/856/681/23/85668123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.250202,
-    "geom:area_square_m":2378605962.373631,
+    "geom:area_square_m":2378605956.693638,
     "geom:bbox":"45.074999,39.487513,45.809177,39.999058",
     "geom:latitude":39.751157,
     "geom:longitude":45.441486,
@@ -383,12 +383,14 @@
         "gn:id":409315,
         "gp:id":20070205,
         "hasc:id":"AM.VD",
+        "iso:code":"AM-VD",
         "iso:id":"AM-VD",
         "qs_pg:id":1064704,
         "wd:id":"Q200124"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AM",
-    "wof:geomhash":"d3051d2a33d1077b3c654fff4e9e62ed",
+    "wof:geomhash":"17c7f18b6111c7b0961f3da6970d6925",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -403,7 +405,7 @@
     "wof:lang_x_spoken":[
         "hye"
     ],
-    "wof:lastmodified":1690849803,
+    "wof:lastmodified":1695884798,
     "wof:name":"Vayots Dzor",
     "wof:parent_id":85632773,
     "wof:placetype":"region",

--- a/data/890/420/051/890420051.geojson
+++ b/data/890/420/051/890420051.geojson
@@ -58,7 +58,7 @@
     },
     "wof:country":"AM",
     "wof:created":1469051314,
-    "wof:geomhash":"a049c8c814681e9ab032432a64376f01",
+    "wof:geomhash":"ccf86f96a8fce11e49b3f8a81381fd4f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":890420051,
-    "wof:lastmodified":1627521474,
+    "wof:lastmodified":1695886720,
     "wof:name":"Arabkir",
     "wof:parent_id":85668115,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.