### PR TITLE
[WIP] Deduplicate records, supersede, swap properties, concordances

### DIFF
--- a/data/120/921/170/1/1209211701.geojson
+++ b/data/120/921/170/1/1209211701.geojson
@@ -29,6 +29,15 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:fas_x_preferred":[
+        "\u0646\u0631\u06a9\u06cc\u0646 \u062f\u0698\u0631\u0627\u067e\u06cc"
+    ],
+    "name:hye_x_preferred":[
+        "Jrap\u2019i"
+    ],
+    "name:hye_x_variant":[
+        "\u054b\u0580\u0561\u0583\u056b"
+    ],
     "name:und_x_variant":[
         "Dzhrapi",
         "Jrap\u2019i"
@@ -39,7 +48,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "gn:id":616728
+        "gn:id":616728,
+        "wk:page":"Nerkin_Dzhrapi"
+    },
+    "wof:concordances_alt":{
+        "gn:id":[
+            616376
+        ]
     },
     "wof:country":"AM",
     "wof:geomhash":"6bdfeadd5e7567a8845a2850d159072c",
@@ -50,13 +65,15 @@
         }
     ],
     "wof:id":1209211701,
-    "wof:lastmodified":1566585265,
+    "wof:lastmodified":1706219587,
     "wof:name":"Jrap'i",
     "wof:parent_id":85632773,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1242696135
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/120/970/751/1/1209707511.geojson
+++ b/data/120/970/751/1/1209707511.geojson
@@ -46,6 +46,11 @@
     "wof:concordances":{
         "gn:id":11341825
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            11341826
+        ]
+    },
     "wof:country":"AM",
     "wof:geomhash":"103f99f475ecd11922272ee08e947c71",
     "wof:hierarchy":[
@@ -58,13 +63,15 @@
         }
     ],
     "wof:id":1209707511,
-    "wof:lastmodified":1566585247,
+    "wof:lastmodified":1706219587,
     "wof:name":"Khorroch'aver",
     "wof:parent_id":1108782667,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1243475725
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/120/980/786/9/1209807869.geojson
+++ b/data/120/980/786/9/1209807869.geojson
@@ -46,6 +46,11 @@
     "wof:concordances":{
         "gn:id":11323361
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            11323362
+        ]
+    },
     "wof:country":"AM",
     "wof:geomhash":"96b8dbd8faf9195888c1d39ff48bc75c",
     "wof:hierarchy":[
@@ -58,13 +63,15 @@
         }
     ],
     "wof:id":1209807869,
-    "wof:lastmodified":1566585262,
+    "wof:lastmodified":1706219587,
     "wof:name":"Bover",
     "wof:parent_id":1108783171,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1343383259
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/122/666/607/5/1226666075.geojson
+++ b/data/122/666/607/5/1226666075.geojson
@@ -46,6 +46,11 @@
     "wof:concordances":{
         "gn:id":11330622
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            11330621
+        ]
+    },
     "wof:country":"AM",
     "wof:geomhash":"266b9766d81a09d50becaf211d4dfb05",
     "wof:hierarchy":[
@@ -58,13 +63,15 @@
         }
     ],
     "wof:id":1226666075,
-    "wof:lastmodified":1566585607,
+    "wof:lastmodified":1706219587,
     "wof:name":"Anapat",
     "wof:parent_id":1108784243,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1344147701
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/124/269/613/5/1242696135.geojson
+++ b/data/124/269/613/5/1242696135.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"43.68082,40.55532,43.68082,40.55532",
@@ -27,7 +29,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:fas_x_preferred":[
         "\u0646\u0631\u06a9\u06cc\u0646 \u062f\u0698\u0631\u0627\u067e\u06cc"
@@ -67,12 +69,14 @@
         }
     ],
     "wof:id":1242696135,
-    "wof:lastmodified":1566585552,
+    "wof:lastmodified":1706219587,
     "wof:name":"Jrap'i",
     "wof:parent_id":1108783427,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1209211701
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/288/705/9/1242887059.geojson
+++ b/data/124/288/705/9/1242887059.geojson
@@ -46,6 +46,11 @@
     "wof:concordances":{
         "gn:id":11225557
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            11225558
+        ]
+    },
     "wof:country":"AM",
     "wof:geomhash":"1688174d62f7c0511fb99018f4e8f946",
     "wof:hierarchy":[
@@ -58,13 +63,15 @@
         }
     ],
     "wof:id":1242887059,
-    "wof:lastmodified":1566585543,
+    "wof:lastmodified":1706219588,
     "wof:name":"Chgnavori Dasht",
     "wof:parent_id":1108782977,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1293592321
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/124/334/798/9/1243347989.geojson
+++ b/data/124/334/798/9/1243347989.geojson
@@ -29,17 +29,47 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:ara_x_preferred":[
+        "\u063a\u0627\u0646\u062c\u0627\u0643\u0627\u0631"
+    ],
     "name:aze_x_preferred":[
         "Qandzakar"
     ],
     "name:aze_x_variant":[
         "Yuxar\u0131 A\u011fdan"
     ],
+    "name:ell_x_preferred":[
+        "\u0393\u03ba\u03b1\u03bd\u03c4\u03b6\u03b1\u03ba\u03ac\u03c1"
+    ],
+    "name:eng_x_preferred":[
+        "Gandzak'ar"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u06af\u062f\u0627\u0646"
     ],
+    "name:fra_x_preferred":[
+        "Gandzakar"
+    ],
     "name:hye_x_preferred":[
         "\u0533\u0561\u0576\u0571\u0561\u0584\u0561\u0580"
+    ],
+    "name:ita_x_preferred":[
+        "Gandzakar"
+    ],
+    "name:kat_x_preferred":[
+        "\u10d2\u10d0\u10dc\u10eb\u10d0\u10e5\u10d0\u10e0\u10d8"
+    ],
+    "name:msa_x_preferred":[
+        "Gandzakar"
+    ],
+    "name:rus_x_preferred":[
+        "\u0413\u0430\u043d\u0434\u0437\u0430\u043a\u0430\u0440"
+    ],
+    "name:sco_x_preferred":[
+        "Gandzakar"
+    ],
+    "name:spa_x_preferred":[
+        "Gandzakar"
     ],
     "name:und_x_variant":[
         "Verkhniy Agdan",
@@ -50,6 +80,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0627\u06af\u062f\u0627\u0646"
+    ],
+    "name:vie_x_preferred":[
+        "Gandzakar"
     ],
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -63,6 +96,14 @@
         "gn:id":617016,
         "wk:page":"Agdan"
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            823750
+        ],
+        "wk:page":[
+            "Gandzakar"
+        ]
+    },
     "wof:country":"AM",
     "wof:geomhash":"e5f3f67da6e1cacfc3681f8c16e21f36",
     "wof:hierarchy":[
@@ -75,13 +116,15 @@
         }
     ],
     "wof:id":1243347989,
-    "wof:lastmodified":1566585558,
+    "wof:lastmodified":1706219588,
     "wof:name":"Gandzak'ar",
     "wof:parent_id":1108783315,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1310685591
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/124/347/572/5/1243475725.geojson
+++ b/data/124/347/572/5/1243475725.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"43.9375,40.8111,43.9375,40.8111",
@@ -27,7 +29,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:hye_x_preferred":[
         "Khorroch\u2019aver"
@@ -58,12 +60,14 @@
         }
     ],
     "wof:id":1243475725,
-    "wof:lastmodified":1566585554,
+    "wof:lastmodified":1706219587,
     "wof:name":"Khorroch'aver",
     "wof:parent_id":1108782667,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1209707511
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/125/980/476/9/1259804769.geojson
+++ b/data/125/980/476/9/1259804769.geojson
@@ -46,6 +46,11 @@
     "wof:concordances":{
         "gn:id":11341402
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            11341403
+        ]
+    },
     "wof:country":"AM",
     "wof:geomhash":"29ab6479c927f083905b649846b42bc3",
     "wof:hierarchy":[
@@ -58,13 +63,15 @@
         }
     ],
     "wof:id":1259804769,
-    "wof:lastmodified":1566585590,
+    "wof:lastmodified":1706219588,
     "wof:name":"Nerk'in Bandivan",
     "wof:parent_id":1108782597,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1343382521
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/127/664/035/3/1276640353.geojson
+++ b/data/127/664/035/3/1276640353.geojson
@@ -58,6 +58,11 @@
     "wof:concordances":{
         "gn:id":11342987
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            11342986
+        ]
+    },
     "wof:country":"AM",
     "wof:geomhash":"e39d370a59691c5268f9d3d8efa9ba9a",
     "wof:hierarchy":[
@@ -70,13 +75,15 @@
         }
     ],
     "wof:id":1276640353,
-    "wof:lastmodified":1566585232,
+    "wof:lastmodified":1706219588,
     "wof:name":"Chermakavan",
     "wof:parent_id":1108783259,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1309995691
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/129/311/134/3/1293111343.geojson
+++ b/data/129/311/134/3/1293111343.geojson
@@ -29,11 +29,17 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:fas_x_preferred":[
+        "\u06af\u0644\u0627\u06cc\u0633\u0648\u0631"
+    ],
     "name:hye_x_preferred":[
         "Marginargiz"
     ],
     "name:hye_x_variant":[
         "\u0544\u0561\u0580\u0563\u056b\u0576\u0561\u0580\u0563\u056b\u0566"
+    ],
+    "name:und_x_variant":[
+        "Gelaysor"
     ],
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -43,7 +49,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "gn:id":11128664
+        "gn:id":11128664,
+        "wk:page":"Gelaysor"
+    },
+    "wof:concordances_alt":{
+        "gn:id":[
+            616676
+        ]
     },
     "wof:country":"AM",
     "wof:geomhash":"611bd0f64f3cf47d76923307e1271e1c",
@@ -56,13 +68,15 @@
         }
     ],
     "wof:id":1293111343,
-    "wof:lastmodified":1566585200,
+    "wof:lastmodified":1706219588,
     "wof:name":"Marginargiz",
     "wof:parent_id":85668099,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1360294087
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/129/359/232/1/1293592321.geojson
+++ b/data/129/359/232/1/1293592321.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"44.9043,39.85553,44.9043,39.85553",
@@ -27,7 +29,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:hye_x_preferred":[
         "Chgnavori Dasht"
@@ -58,12 +60,14 @@
         }
     ],
     "wof:id":1293592321,
-    "wof:lastmodified":1566585190,
+    "wof:lastmodified":1706219587,
     "wof:name":"Chgnavori Dasht",
     "wof:parent_id":1108782977,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1242887059
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/130/999/569/1/1309995691.geojson
+++ b/data/130/999/569/1/1309995691.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"45.0293,40.70709,45.0293,40.70709",
@@ -27,7 +29,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:aze_x_preferred":[
         "A\u011fkils\u0259"
@@ -70,12 +72,14 @@
         }
     ],
     "wof:id":1309995691,
-    "wof:lastmodified":1566585478,
+    "wof:lastmodified":1706219588,
     "wof:name":"Chermakavan",
     "wof:parent_id":1108783259,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1276640353
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/010/677/5/1310106775.geojson
+++ b/data/131/010/677/5/1310106775.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"45.35498,40.59655,45.35498,40.59655",
@@ -27,7 +29,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:aze_x_preferred":[
         "\u00c7\u0259mb\u0259r\u0259k"
@@ -78,12 +80,14 @@
         }
     ],
     "wof:id":1310106775,
-    "wof:lastmodified":1566585457,
+    "wof:lastmodified":1706219587,
     "wof:name":"Chambarak",
     "wof:parent_id":1108783369,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        421179787
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/068/559/1/1310685591.geojson
+++ b/data/131/068/559/1/1310685591.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"45.16158,40.84373,45.16158,40.84373",
@@ -27,7 +29,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u063a\u0627\u0646\u062c\u0627\u0643\u0627\u0631"
@@ -98,12 +100,14 @@
         }
     ],
     "wof:id":1310685591,
-    "wof:lastmodified":1566585461,
+    "wof:lastmodified":1706219588,
     "wof:name":"Gandzak'ar",
     "wof:parent_id":1108783315,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1243347989
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/713/748/3/1327137483.geojson
+++ b/data/132/713/748/3/1327137483.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"44.58678,39.87403,44.58678,39.87403",
@@ -27,7 +29,7 @@
     "lbl:max_zoom":15.0,
     "lbl:min_zoom":11.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":11.0,
     "name:hye_x_preferred":[
         "Lusarrat"
@@ -68,14 +70,16 @@
         }
     ],
     "wof:id":1327137483,
-    "wof:lastmodified":1566585116,
+    "wof:lastmodified":1706219587,
     "wof:name":"Lusarrat",
     "wof:parent_id":1108783307,
     "wof:placetype":"locality",
     "wof:population":2780,
     "wof:population_rank":4,
     "wof:repo":"whosonfirst-data-admin-am",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        421192595
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/338/252/1/1343382521.geojson
+++ b/data/134/338/252/1/1343382521.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"43.79449,40.95428,43.79449,40.95428",
@@ -27,7 +29,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:hye_x_preferred":[
         "Nerk\u2019in Bandivan"
@@ -58,12 +60,14 @@
         }
     ],
     "wof:id":1343382521,
-    "wof:lastmodified":1566585136,
+    "wof:lastmodified":1706219588,
     "wof:name":"Nerk'in Bandivan",
     "wof:parent_id":1108782597,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1259804769
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/338/325/9/1343383259.geojson
+++ b/data/134/338/325/9/1343383259.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"44.82507,41.10968,44.82507,41.10968",
@@ -27,7 +29,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:hye_x_preferred":[
         "Bover"
@@ -58,12 +60,14 @@
         }
     ],
     "wof:id":1343383259,
-    "wof:lastmodified":1566585135,
+    "wof:lastmodified":1706219587,
     "wof:name":"Bover",
     "wof:parent_id":1108783171,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1209807869
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/414/770/1/1344147701.geojson
+++ b/data/134/414/770/1/1344147701.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"46.07092,39.50848,46.07092,39.50848",
@@ -27,7 +29,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:hye_x_preferred":[
         "Anapat"
@@ -58,12 +60,14 @@
         }
     ],
     "wof:id":1344147701,
-    "wof:lastmodified":1566585143,
+    "wof:lastmodified":1706219587,
     "wof:name":"Anapat",
     "wof:parent_id":1108784243,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1226666075
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/136/029/408/7/1360294087.geojson
+++ b/data/136/029/408/7/1360294087.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"44.81622,40.06101,44.81622,40.06101",
@@ -27,7 +29,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:fas_x_preferred":[
         "\u06af\u0644\u0627\u06cc\u0633\u0648\u0631"
@@ -63,12 +65,14 @@
         }
     ],
     "wof:id":1360294087,
-    "wof:lastmodified":1566585473,
+    "wof:lastmodified":1706219588,
     "wof:name":"Marginargiz",
     "wof:parent_id":85668099,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-am",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1293111343
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/421/179/787/421179787.geojson
+++ b/data/421/179/787/421179787.geojson
@@ -9,6 +9,19 @@
     "geom:bbox":"45.35498,40.59655,45.35498,40.59655",
     "geom:latitude":40.59655,
     "geom:longitude":45.35498,
+    "gn:admin1_code":"04",
+    "gn:asciiname":"Chambarak",
+    "gn:country_code":"AM",
+    "gn:dem":1848,
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":616098,
+    "gn:latitude":40.59655,
+    "gn:longitude":45.35498,
+    "gn:modification_date":"2018-01-10",
+    "gn:name":"Chambarak",
+    "gn:population":0,
+    "gn:timezone":"Asia/Yerevan",
     "iso:country":"AM",
     "lbl:bbox":"45.33498,40.57655,45.37498,40.61655",
     "lbl:max_zoom":15.0,
@@ -25,6 +38,9 @@
     ],
     "name:aze_x_preferred":[
         "\u00c7\u0259mb\u0259r\u0259k"
+    ],
+    "name:aze_x_variant":[
+        "Yuxar\u0131 \u00c7\u0259mb\u0259r\u0259k"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0427\u0430\u043c\u0431\u0430\u0440\u0430\u043a"
@@ -66,6 +82,9 @@
         "\u010cambarak"
     ],
     "name:hye_x_preferred":[
+        "\u0543\u0561\u0574\u0562\u0561\u0580\u0561\u056f"
+    ],
+    "name:hye_x_variant":[
         "\u0543\u0561\u0574\u0562\u0561\u0580\u0561\u056f"
     ],
     "name:ind_x_preferred":[
@@ -187,6 +206,14 @@
         "wd:id":"Q1024822",
         "wk:page":"Chambarak"
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            616098
+        ],
+        "wk:page":[
+            "Verin-Chambarak"
+        ]
+    },
     "wof:country":"AM",
     "wof:created":1459009233,
     "wof:geomhash":"53a70c1254085cec3f25ede9645d65b0",
@@ -200,7 +227,7 @@
         }
     ],
     "wof:id":421179787,
-    "wof:lastmodified":1690849855,
+    "wof:lastmodified":1706219587,
     "wof:name":"Chambarak",
     "wof:parent_id":1108783369,
     "wof:placetype":"locality",
@@ -208,7 +235,9 @@
     "wof:population_rank":5,
     "wof:repo":"whosonfirst-data-admin-am",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1310106775
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/421/192/595/421192595.geojson
+++ b/data/421/192/595/421192595.geojson
@@ -9,6 +9,19 @@
     "geom:bbox":"44.58961,39.87398,44.58961,39.87398",
     "geom:latitude":39.87398,
     "geom:longitude":44.58961,
+    "gn:admin1_code":"02",
+    "gn:asciiname":"Lusarrat",
+    "gn:country_code":"AM",
+    "gn:dem":821,
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":174770,
+    "gn:latitude":39.87403,
+    "gn:longitude":44.58678,
+    "gn:modification_date":"2018-03-16",
+    "gn:name":"Lusarrat",
+    "gn:population":2780,
+    "gn:timezone":"Asia/Yerevan",
     "iso:country":"AM",
     "lbl:bbox":"44.56961,39.85398,44.60961,39.89398",
     "lbl:max_zoom":18.0,
@@ -44,6 +57,9 @@
     "name:hye_x_preferred":[
         "\u053c\u0578\u0582\u057d\u0561\u057c\u0561\u057f"
     ],
+    "name:hye_x_variant":[
+        "\u053c\u0578\u0582\u057d\u0561\u057c\u0561\u057f"
+    ],
     "name:ita_x_preferred":[
         "Lusarat"
     ],
@@ -70,6 +86,11 @@
     ],
     "name:ukr_x_preferred":[
         "\u041b\u0443\u0441\u0430\u0440\u0430\u0442"
+    ],
+    "name:und_x_variant":[
+        "Shkhlar",
+        "Shikhlar",
+        "Lusarat"
     ],
     "name:uzb_x_preferred":[
         "Lusarat"
@@ -99,6 +120,7 @@
     "qs:woe_adm0":23424743,
     "qs:woe_id":2214088,
     "src:geom":"quattroshapes",
+    "src:population":"geonames",
     "wd:wordcount":150,
     "wof:belongsto":[
         102191569,
@@ -114,6 +136,14 @@
         "wd:id":"Q2371758",
         "wk:page":"Lusarat"
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            174770
+        ],
+        "wk:page":[
+            "Shikhlar"
+        ]
+    },
     "wof:country":"AM",
     "wof:created":1459009742,
     "wof:geomhash":"d7b3833c2e3943c1dda9dca5ce2d7f9a",
@@ -127,13 +157,17 @@
         }
     ],
     "wof:id":421192595,
-    "wof:lastmodified":1690849810,
+    "wof:lastmodified":1706219587,
     "wof:name":"Lusarrat",
     "wof:parent_id":1108783307,
     "wof:placetype":"locality",
+    "wof:population":2780,
+    "wof:population_rank":4,
     "wof:repo":"whosonfirst-data-admin-am",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1327137483
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/859/037/25/85903725.geojson
+++ b/data/859/037/25/85903725.geojson
@@ -25,6 +25,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":13.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":2,
     "name:eng_x_preferred":[
         "Charbakh"
@@ -50,12 +51,31 @@
     "qs:woe_lau":0,
     "qs:woe_local":2214662,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:name":"Charbakh",
+    "qs_pg:name_adm0":"Armenia",
+    "qs_pg:name_adm1":"Armavir",
+    "qs_pg:photos":2430,
+    "qs_pg:photos_1k":492,
+    "qs_pg:photos_9k":11,
+    "qs_pg:photos_9r":10,
+    "qs_pg:photos_all":2430,
+    "qs_pg:photos_sr":17,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":1130257,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424743,
+    "qs_pg:woe_id":2213655,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
     "wd:wordcount":10,
+    "woe:adm0_id":23424743,
+    "woe:name_adm0":"Armenia",
+    "woe:name_adm1":"Armavir",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         102191569,
         85632773,
@@ -65,6 +85,14 @@
     "wof:concordances":{
         "gp:id":2213655,
         "qs_pg:id":1130257
+    },
+    "wof:concordances_alt":{
+        "gp:id":[
+            2213655
+        ],
+        "qs_pg:id":[
+            1130257
+        ]
     },
     "wof:country":"AM",
     "wof:geom_alt":[
@@ -84,13 +112,15 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1697478372,
+    "wof:lastmodified":1706219587,
     "wof:name":"Charbakh",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-am",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126090537
+    ],
     "wof:tags":[]
 },
   "bbox": [


### PR DESCRIPTION
Round two... this PR updates duplicate records within WOF. When a duplicate pair/set is found:

- One record is superseded into the other
- Properties are transferred from the superseded record to the superseding record (if the property doesn't already exist)
- Concordances are transferred from the superseded record to the superseding record. If the concordance exists, a `wof:concordances_alt` property is used. If the concordance doesn't exist, it's added to the `wof:concordances` property

Duplicates were found by scoping a single placetype, checking for records with geometries near one another and identical (or nearly identical) names. Duplicate pairs were found the following way:

- If two point geometries: within 300m of one another
  - The older record of the two is kept, the newest is superseded
- If one point and one polygon: point is within the polygon OR point is within 300m of the polygon record's centroid
  - The record with the polygon is kept, the point is superseded
- If two polygon geometries: polygons overlap OR both records' centroids are within 300m of one another
  - The older record of the two is kept, the newest is superseded

Because this work is not scoped to a single repo, this work will also catch (many) cases where duplicates exist across two or more repos (one record in `whosonfirst-data-admin-xx` and `whosonfirst-data-admin-cr`, for example). I'm sure there are some edge cases that won't be caught with these parameters, but the duplicates I've reviewed have been legitimate. No PIP work needed - once this is approved, I'll open a few more PRs for review before running against all admin repos.